### PR TITLE
fix QuantumMaelstrom damage

### DIFF
--- a/Bugfix by Uveso.txt
+++ b/Bugfix by Uveso.txt
@@ -1,6 +1,7 @@
 v21 (05.Dec.2024)
 
 - Fixed the hitboxes of ACUs, especially the Aeon hitbox, which was far too small.
+- Reduced damage for (Aeon) QuantumMaelstrom T1 7->3, T2 17->6, T3 32->9
 
 *************************************************************************************************************************************
 v20 (02.Nov.2024)

--- a/units/EAL0001/EAL0001_unit.bp
+++ b/units/EAL0001/EAL0001_unit.bp
@@ -1286,7 +1286,7 @@ UnitBlueprint {
             Name = 'Quantum Distortion Amplifier (T3)',
             Prerequisite = 'MaelstromQuantum',
             NewHealth = 8000,
-            MaelstromDamage = 17,
+            MaelstromDamage = 6,
             ShowBones = {
                 'DamagePack_LArm',
                 'DamagePack_RArm',
@@ -1342,7 +1342,7 @@ UnitBlueprint {
             Name = 'Quantum Instability Enhancer (T4)',
             Prerequisite = 'DistortionAmplifier',
             NewHealth = 15000,
-            MaelstromDamage = 32,
+            MaelstromDamage = 9,
             MaelstromRadius = 30,
             ShowBones = {
                 'DamagePack_LArm',
@@ -2412,7 +2412,7 @@ UnitBlueprint {
             BallisticArc = 'RULEUBA_None',
             CanFireFromTransport = true,
             CollideFriendly = false,
-            Damage = 7,
+            Damage = 3,
             DamageFriendly = false,
             DamageRadius = 22,
             DamageType = 'Overcharge',


### PR DESCRIPTION
Changed damage for QuantumMaelstrom:

TECH1 from 7 to 3
TECH2 from 17 to 6
TECH3 from 32 to 9
